### PR TITLE
cmd/darvaza: clean up config handling

### DIFF
--- a/cmd/darvaza/config.go
+++ b/cmd/darvaza/config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"io"
 	"log"
-	"sync"
 
 	"github.com/creasty/defaults"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -12,7 +11,6 @@ import (
 )
 
 type Config struct {
-	sync.WaitGroup
 	Proxies []Proxy `hcl:"proxy,block"`
 }
 
@@ -24,14 +22,6 @@ func (c *Config) SetDefaults() {
 	if defaults.CanUpdate(c.Proxies) {
 		c.Proxies = append(c.Proxies, *defaultProxy)
 	}
-}
-
-func (c *Config) RunProxies() {
-	for i := range c.Proxies {
-		cfg.Add(1)
-		go c.Proxies[i].Run()
-	}
-	cfg.Wait()
 }
 
 func NewConfig() *Config {

--- a/cmd/darvaza/serve.go
+++ b/cmd/darvaza/serve.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"sync"
+
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +11,15 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "starts serving a proxy",
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg.RunProxies()
+		var wg sync.WaitGroup
+		for i := range cfg.Proxies {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				cfg.Proxies[i].Run()
+			}(i)
+		}
+		wg.Wait()
 	},
 }
 

--- a/cmd/darvaza/server.go
+++ b/cmd/darvaza/server.go
@@ -32,7 +32,6 @@ func (p *Proxy) listeners() []net.Listener {
 }
 
 func (p *Proxy) Run() {
-	defer cfg.Done()
 	ls := p.listeners()
 	for {
 		for _, l := range ls {


### PR DESCRIPTION
and move proxy starting logic to its proper location.
Closes #1

Signed-off-by: Nagy Károly Gábriel <k@jpi.io>