### PR TITLE
storage/: fix issue #9

### DIFF
--- a/storage/file/filestore_test.go
+++ b/storage/file/filestore_test.go
@@ -3,6 +3,7 @@ package file
 /*
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"testing"
 )
@@ -14,7 +15,11 @@ func Test_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
-	cert, err := z.Get(ctx, "www.example.com")
+	certdata, err := z.Get(ctx, "www.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(certdata)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -3,17 +3,21 @@ package storage
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 )
+
+// ErrStorageMiss is returned when a certificate is not found in the storage.
+var ErrStorageMiss = errors.New("darvaza/: certificate storage miss")
 
 type StoreIterFunc func(x509.Certificate) error
 
 type ReadStore interface {
-	Get(ctx context.Context, name string) (x509.Certificate, error)
+	Get(ctx context.Context, name string) ([]byte, error)
 	ForEach(ctx context.Context, f StoreIterFunc) error
 }
 
 type WriteStore interface {
-	Put(ctx context.Context, name string, cert x509.Certificate) error
+	Put(ctx context.Context, name string, cert []byte) error
 	Delete(ctx context.Context, name string) error
-	DeleteCert(ctx context.Context, cert x509.Certificate) error
+	DeleteCert(ctx context.Context, cert []byte) error
 }


### PR DESCRIPTION
also removed 
``` go 
func (fs *FileStore) DeleteCert(ctx context.Context, cert x509.Certificate) error
```
because it was a defective implementation.
If really needed please open a new issue.
Signed-off-by: Nagy Károly Gábriel <k@jpi.io>