### PR TITLE
Prevent `make build` from dropping binaries in `.`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,20 +7,20 @@ GOGENERATE_FLAGS = -v
 
 PROJECTS = acme agent server shared
 
-TEMPDIR ?= .tmp
+TMPDIR ?= .tmp
 
 all: get generate fmt tidy build
 
 clean:
-	rm -rf $(TEMPDIR)
+	rm -rf $(TMPDIR)
 
-$(TEMPDIR)/gen.mk: scripts/gen_mk.sh Makefile
+$(TMPDIR)/gen.mk: scripts/gen_mk.sh Makefile
 	@echo "$< $(PROJECTS) > $@" >&2
 	@mkdir -p $(@D)
 	@$< $(PROJECTS) > $@~
 	@if cmp $@ $@~ 2> /dev/null >&2; then rm $@~; else mv $@~ $@; fi
 
-include $(TEMPDIR)/gen.mk
+include $(TMPDIR)/gen.mk
 
 fmt:
 	@find . -name '*.go' | xargs -r $(GOFMT) $(GOFMT_FLAGS)

--- a/shared/go.mod
+++ b/shared/go.mod
@@ -1,3 +1,8 @@
 module github.com/darvaza-proxy/darvaza/shared
 
 go 1.18
+
+require (
+	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
+)

--- a/shared/go.sum
+++ b/shared/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
+golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
`go build` doesn't use `$GOBIN` as of go 1.18, and by default, it just drops the built commands at the source dir.

This PR changes the generator so the output of `make build` ends in `$(TMPDIR)` which currently defaults to `.tmp`, together with `gen.mk` itself.

this PR also add some missing entries on `shared` and `agent`'s `go.mod` and `go.sum`