### PR TITLE
shared/net: introduce Listen related helpers

### DIFF
--- a/shared/net/addrs.go
+++ b/shared/net/addrs.go
@@ -74,3 +74,27 @@ func JoinAllHostPorts(addresses []string, ports []uint16) ([]string, error) {
 
 	return out, nil
 }
+
+// InterfaceAddresses returns the list of IP addresses of a list of network
+// interfaces
+func InterfaceAddresses(ifaces []string) ([]string, error) {
+	var out []string
+
+	for _, name := range ifaces {
+		ifi, err := net.InterfaceByName(name)
+		if err != nil {
+			return out, err
+		}
+
+		addrs, err := ifi.Addrs()
+		if err != nil {
+			return out, err
+		}
+
+		for _, addr := range addrs {
+			out = append(out, addr.String())
+		}
+	}
+
+	return out, nil
+}

--- a/shared/net/addrs.go
+++ b/shared/net/addrs.go
@@ -6,6 +6,28 @@ import (
 	"strings"
 )
 
+// JoinHostPort combines a given host address and a port, validating
+// the provided IP address in the process
+func JoinHostPort(host string, port uint16) (string, error) {
+	ip, err := net.ResolveIPAddr("ip", host)
+	if err != nil {
+		// bad address
+		return "", err
+	} else if ip == nil || ip.IP.IsUnspecified() {
+		// wildcard
+		host = ""
+	} else {
+		host = ip.String()
+
+		if strings.ContainsRune(host, ':') {
+			// IPv6
+			host = fmt.Sprintf("[%s]", host)
+		}
+	}
+
+	return fmt.Sprintf("%s:%v", host, port), nil
+}
+
 // JoinAllHostPorts combines a list of addresses and a list of ports, validating
 // the provided IP addresses in the process
 func JoinAllHostPorts(addresses []string, ports []uint16) ([]string, error) {

--- a/shared/net/addrs.go
+++ b/shared/net/addrs.go
@@ -3,8 +3,24 @@ package net
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 )
+
+// SplitHostPort splits a network address into host and port,
+// validating the port in the process
+func SplitHostPort(hostport string) (string, uint16, error) {
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		return "", 0, err
+	} else if port == "" {
+		return host, 0, nil
+	} else if u, err := strconv.ParseUint(port, 10, 16); err != nil {
+		return "", 0, err
+	} else {
+		return host, uint16(u & 0xffff), nil
+	}
+}
 
 // JoinHostPort combines a given host address and a port, validating
 // the provided IP address in the process

--- a/shared/net/addrs.go
+++ b/shared/net/addrs.go
@@ -1,0 +1,38 @@
+package net
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+// JoinAllHostPorts combines a list of addresses and a list of ports, validating
+// the provided IP addresses in the process
+func JoinAllHostPorts(addresses []string, ports []uint16) ([]string, error) {
+	var out []string
+
+	for _, s := range addresses {
+
+		ip, err := net.ResolveIPAddr("ip", s)
+		if err != nil {
+			// bad address
+			return out, err
+		} else if ip == nil || ip.IP.IsUnspecified() {
+			// wildcard
+			s = ""
+		} else {
+			s = ip.String()
+
+			if strings.ContainsRune(s, ':') {
+				// IPv6
+				s = fmt.Sprintf("[%s]", s)
+			}
+		}
+
+		for _, p := range ports {
+			out = append(out, fmt.Sprintf("%s:%v", s, p))
+		}
+	}
+
+	return out, nil
+}

--- a/shared/net/listen.go
+++ b/shared/net/listen.go
@@ -1,0 +1,73 @@
+package net
+
+import (
+	"context"
+	"net"
+)
+
+// ListenConfig extends the standard net.ListeConfig with a central holder
+// for the Context bound to the listeners
+type ListenConfig struct {
+	net.ListenConfig
+
+	// Context used when registering the listeners
+	Context context.Context
+}
+
+// Listen acts like the standard net.Listen but using the context.Context,
+// KeepAlive, and optional Control function from our ListenConfig struct
+func (lc ListenConfig) Listen(network, addr string) (net.Listener, error) {
+	ctx := lc.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	return lc.ListenConfig.Listen(ctx, network, addr)
+}
+
+// ListenPacket acts like the standard net.ListenPacket but using the context.Context,
+// KeepAlive, and optional Control function from our ListenConfig struct
+func (lc ListenConfig) ListenPacket(network, addr string) (net.PacketConn, error) {
+	ctx := lc.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	return lc.ListenConfig.ListenPacket(ctx, network, addr)
+}
+
+// ListenAllPacket acts like Listen but on a list of addresses
+func (lc ListenConfig) ListenAll(network string, addrs []string) ([]net.Listener, error) {
+	var out []net.Listener
+
+	for _, addr := range addrs {
+		lsn, err := lc.Listen(network, addr)
+		if err != nil {
+			for _, lsn := range out {
+				lsn.Close()
+			}
+			return nil, err
+		}
+		out = append(out, lsn)
+	}
+
+	return out, nil
+}
+
+// ListenAllPacket acts like ListenPacket but on a list of addresses
+func (lc ListenConfig) ListenAllPacket(network string, addrs []string) ([]net.PacketConn, error) {
+	var out []net.PacketConn
+
+	for _, addr := range addrs {
+		lsn, err := lc.ListenPacket(network, addr)
+		if err != nil {
+			for _, lsn := range out {
+				lsn.Close()
+			}
+			return nil, err
+		}
+		out = append(out, lsn)
+	}
+
+	return out, nil
+}

--- a/shared/net/listen.go
+++ b/shared/net/listen.go
@@ -3,6 +3,7 @@ package net
 import (
 	"context"
 	"net"
+	"time"
 )
 
 // ListenConfig extends the standard net.ListeConfig with a central holder
@@ -12,6 +13,21 @@ type ListenConfig struct {
 
 	// Context used when registering the listeners
 	Context context.Context
+}
+
+// NewListenConfig assists creating a ListenConfig due to the two-layer definition
+// making difficult static declaration when `net` is shadowed
+func NewListenConfig(ctx context.Context, keepalive time.Duration) *ListenConfig {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	return &ListenConfig{
+		ListenConfig: net.ListenConfig{
+			KeepAlive: keepalive,
+		},
+		Context: ctx,
+	}
 }
 
 // Listen acts like the standard net.Listen but using the context.Context,

--- a/shared/net/std.go
+++ b/shared/net/std.go
@@ -1,0 +1,12 @@
+package net
+
+import (
+	"net"
+)
+
+type (
+	// Alias of the standard net.Conn
+	Conn = net.Conn
+	// Alias of the standard net.Listener
+	Listener = net.Listener
+)


### PR DESCRIPTION
 introduce Listen related helpers intended to aid case where we have to listen on multiple (but not all) addresses on a machine