### PR TITLE
fix `make tidy` to not run `revive` on subprojects twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ REVIVE ?= $(GOBIN)/revive
 REVIVE_FLAGS ?= -formatter friendly
 REVIVE_INSTALL_URL ?= github.com/mgechev/revive
 
-PROJECTS = acme agent server shared
+PROJECTS = shared acme agent server
 
 TMPDIR ?= .tmp
 

--- a/tools/gen_mk.sh
+++ b/tools/gen_mk.sh
@@ -107,3 +107,15 @@ $(echo "$callx" | sed -e "/^$/d;" -e "s|^|\t@$cd|")
 EOT
 	done
 done
+
+for x in $PROJECTS; do
+	all=
+	for cmd in get build tidy; do
+		all="${all:+$all }$cmd-$x"
+	done
+
+	cat <<EOT
+$x: $all
+
+EOT
+done

--- a/tools/gen_mk.sh
+++ b/tools/gen_mk.sh
@@ -14,7 +14,7 @@ expand() {
 }
 
 for cmd in $COMMANDS; do
-	all="$(expand $cmd root $PROJECTS)"
+	all="$(expand $cmd $PROJECTS root)"
 	depsx=
 
 	cat <<EOT
@@ -51,7 +51,7 @@ EOT
 		sequential=false ;;
 	esac
 
-	for x in . $PROJECTS; do
+	for x in $PROJECTS .; do
 		if [ "$x" = . ]; then
 			k="root"
 			cd=

--- a/tools/gen_mk.sh
+++ b/tools/gen_mk.sh
@@ -83,6 +83,12 @@ EOT
 				callx="$cmdx
 \$(GO) mod tidy
 \$(GO) install -v \$(REVIVE_INSTALL_URL)"
+			elif [ "tidy" = "$cmd" ]; then
+				exclude=
+				for x in $PROJECTS; do
+					exclude="${exclude:+$exclude }-exclude ./$x/..."
+				done
+				callx=$(echo "$callx" | sed -e "s;\(REVIVE)\);\1 $exclude;")
 			elif [ -n "$cmdx" ]; then
 				callx="$cmdx"
 			fi


### PR DESCRIPTION
`revive` on `make tidy-root` doesn't skip directories containing a `go.mod` like `go tools` do, so the currently generated target makes `revive` process files on `shared`, `acme`, `agent`, and `server` too

```makefile
tidy-root: $(REVIVE)
         @$(GO) mod tidy
         @$(GO) vet ./...
         @$(REVIVE)  $(REVIVE_RUN_ARGS) ./...
```

I couldn't find a better alternative than using `$PROJECTS` in `tools/gen_mk.sh` to compose an exclusion list

```makefile
tidy-root: $(REVIVE)
         @$(GO) mod tidy
         @$(GO) vet ./...
         @$(REVIVE) -exclude ./shared/... -exclude ./acme/... -exclude ./agent/... -exclude ./server/... $(REVIVE_RUN_ARGS) ./...
```
