### PR TITLE
shared/net: add GetNetIPAddresses() and improve GetStringIPAddresses()

### DIFF
--- a/shared/net/addrs.go
+++ b/shared/net/addrs.go
@@ -81,17 +81,16 @@ func JoinAllHostPorts(addresses []string, ports []uint16) ([]string, error) {
 // GetStringIPAddresses returns a list of text IP addresses bound
 // to the given interfaces or all if none are given
 func GetStringIPAddresses(ifaces ...string) ([]string, error) {
-	addrs, err := GetIPAddresses(ifaces...)
+	addrs, err := GetNetIPAddresses(ifaces...)
 
-	// even if GetIPAddresses() failed we convert whatever was returned
-	// before passing the error through
-
-	s := make([]string, len(addrs))
-	for i, v := range addrs {
-		s[i] = v.String()
+	out := make([]string, 0, len(addrs))
+	for _, addr := range addrs {
+		if s := addr.String(); s != "" {
+			out = append(out, s)
+		}
 	}
 
-	return s, err
+	return out, err
 }
 
 // GetNetIPAddresses returns a list of net.IP addresses bound to

--- a/shared/net/addrs.go
+++ b/shared/net/addrs.go
@@ -78,8 +78,8 @@ func JoinAllHostPorts(addresses []string, ports []uint16) ([]string, error) {
 	return out, nil
 }
 
-// GetStringIPAddresses returns the list of IP addresses bound to the given
-// interfaces or all if none are given
+// GetStringIPAddresses returns a list of text IP addresses bound
+// to the given interfaces or all if none are given
 func GetStringIPAddresses(ifaces ...string) ([]string, error) {
 	addrs, err := GetIPAddresses(ifaces...)
 
@@ -94,7 +94,30 @@ func GetStringIPAddresses(ifaces ...string) ([]string, error) {
 	return s, err
 }
 
-// GetIPAddresses returns the list of netip.Addr bound to the given
+// GetNetIPAddresses returns a list of net.IP addresses bound to
+// the given interfaces or all if none are given
+func GetNetIPAddresses(ifaces ...string) ([]net.IP, error) {
+	addrs, err := GetIPAddresses(ifaces...)
+
+	out := make([]net.IP, len(addrs))
+	for i, addr := range addrs {
+		var ip net.IP
+
+		if addr.Is4() || addr.Is4In6() {
+			a4 := addr.As4()
+			ip = a4[:]
+		} else {
+			a16 := addr.As16()
+			ip = a16[:]
+		}
+
+		out[i] = ip
+	}
+
+	return out, err
+}
+
+// GetIPAddresses returns a list of netip.Addr bound to the given
 // interfaces or all if none are given
 func GetIPAddresses(ifaces ...string) ([]netip.Addr, error) {
 	var out []netip.Addr

--- a/shared/net/std.go
+++ b/shared/net/std.go
@@ -7,6 +7,8 @@ import (
 type (
 	// Conn is an alias of the standard net.Conn type
 	Conn = net.Conn
+	// IP is an alias of the stadnard net.IP type
+	IP = net.IP
 	// Listener is an alias of the standard net.Listener type
 	Listener = net.Listener
 )


### PR DESCRIPTION
extend shared/net for better compatibility around net.IP usage and string addresses