### PR TITLE
shared/storage/certpool/poolbuffer: drop certinfo and debug mode

### DIFF
--- a/shared/go.mod
+++ b/shared/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/darvaza-proxy/slog v0.4.5
 	github.com/darvaza-proxy/slog/handlers/cblog v0.4.0
 	github.com/darvaza-proxy/slog/handlers/discard v0.3.0
-	github.com/grantae/certinfo v0.0.0-20170412194111-59d56a35515b
 	github.com/zeebo/blake3 v0.2.3
 	golang.org/x/crypto v0.7.0
 	golang.org/x/sync v0.1.0

--- a/shared/go.sum
+++ b/shared/go.sum
@@ -6,8 +6,6 @@ github.com/darvaza-proxy/slog/handlers/cblog v0.4.0 h1:Cv7yZJL0AW5nw53GidAmviUD/
 github.com/darvaza-proxy/slog/handlers/cblog v0.4.0/go.mod h1:EUYhb/FgcXTsFmOcGO0gFNFknHag4MvHMyQiibOAeX8=
 github.com/darvaza-proxy/slog/handlers/discard v0.3.0 h1:FXMkc7RkjPYK2UEqQRHam1cufGi0AQfm5R3mviM2XRQ=
 github.com/darvaza-proxy/slog/handlers/discard v0.3.0/go.mod h1:z3UslNI3R10KK/6k6B1HZFlYOM1D2/m1kVEJN89Mkcg=
-github.com/grantae/certinfo v0.0.0-20170412194111-59d56a35515b h1:NGgE5ELokSf2tZ/bydyDUKrvd/jP8lrAoPNeBuMOTOk=
-github.com/grantae/certinfo v0.0.0-20170412194111-59d56a35515b/go.mod h1:zT/uzhdQGTqlwTq7Lpbj3JoJQWfPfIJ1tE0OidAmih8=
 github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZXnvk=
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=

--- a/shared/storage/certpool/poolbuffer_logger.go
+++ b/shared/storage/certpool/poolbuffer_logger.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/darvaza-proxy/darvaza/shared/x509utils"
 	"github.com/darvaza-proxy/slog"
-	"github.com/grantae/certinfo"
 )
 
 // SetLogger binds a slog.Logger to the buffer
@@ -125,35 +124,16 @@ func (pb *PoolBuffer) printKey(fn string, pk x509utils.PrivateKey) error {
 			fields["filename"] = fn
 		}
 
-		log.WithFields(fields).Print("Key")
+		log.WithFields(fields).Print("Key Added")
 	}
 	return nil
 }
 
 // revive:disable:cognitive-complexity
-// revive:disable:cyclomatic
 
 func (pb *PoolBuffer) printCert(fn string, cert *x509.Certificate) error {
 	// revive:enable:cognitive-complexity
-	// revive:enable:cyclomatic
-
-	var log slog.Logger
-	var ok bool
-	var err error
-	var msg string
-
-	if log, ok = pb.debug(); ok {
-		msg, err = certinfo.CertificateText(cert)
-		if err != nil {
-			log = log.Error()
-		}
-	} else if log, ok = pb.info(); ok {
-		msg = "Certificate"
-	} else {
-		log = nil
-	}
-
-	if log != nil {
+	if log, ok := pb.info(); ok {
 		fields := slog.Fields{
 			"ca":      cert.IsCA,
 			"subject": cert.Subject.String(),
@@ -169,10 +149,6 @@ func (pb *PoolBuffer) printCert(fn string, cert *x509.Certificate) error {
 			fields["subject-id"] = hexString(cert.SubjectKeyId)
 		}
 
-		if err != nil {
-			fields[slog.ErrorFieldName] = err
-		}
-
 		names, patterns := x509utils.Names(cert)
 		for i, s := range patterns {
 			patterns[i] = "*" + s
@@ -184,8 +160,8 @@ func (pb *PoolBuffer) printCert(fn string, cert *x509.Certificate) error {
 			fields["names"] = names
 		}
 
-		log.WithFields(fields).Print(msg)
+		log.WithFields(fields).Print("Certificate Added")
 	}
 
-	return err
+	return nil
 }


### PR DESCRIPTION
info data is already enough for the PoolBuffer logs and can't justify the additional dependency