### PR TITLE
shared/web: WithErrorHandler/ErrorHandler based on core.NewContextKey

### DIFF
--- a/shared/web/error_handler.go
+++ b/shared/web/error_handler.go
@@ -1,0 +1,26 @@
+package web
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/darvaza-proxy/core"
+)
+
+// ErrorHandlerFunc is the signature of a function used as ErrorHandler
+type ErrorHandlerFunc func(http.ResponseWriter, *http.Request, error)
+
+// WithErrorHandler attaches an ErrorHandler function to a context
+// for later retrieval
+func WithErrorHandler(ctx context.Context, h ErrorHandlerFunc) context.Context {
+	return errCtxKey.WithValue(ctx, h)
+}
+
+// ErrorHandler attempts to pull an ErrorHandler from the context.Context
+func ErrorHandler(ctx context.Context) (ErrorHandlerFunc, bool) {
+	return errCtxKey.Get(ctx)
+}
+
+var (
+	errCtxKey = core.NewContextKey[ErrorHandlerFunc]("ErrorHandler")
+)

--- a/shared/web/errors.go
+++ b/shared/web/errors.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/darvaza-proxy/core"
-	"github.com/darvaza-proxy/middleware"
 )
 
 var (
@@ -42,7 +41,7 @@ func (err *HTTPError) Status() int {
 // ServeHTTP is a very primitive handler that will try to pass the error
 // to a [middleware.ErrorHandlerFunc] provided via the request's context.Context
 func (err *HTTPError) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	if h, ok := middleware.ErrorHandler(req.Context()); ok {
+	if h, ok := ErrorHandler(req.Context()); ok {
 		// pass over to the error handler
 		h(rw, req, err)
 		return

--- a/shared/web/go.mod
+++ b/shared/web/go.mod
@@ -2,10 +2,7 @@ module github.com/darvaza-proxy/darvaza/shared/web
 
 go 1.19
 
-require (
-	github.com/darvaza-proxy/core v0.7.4
-	github.com/darvaza-proxy/middleware v0.0.5
-)
+require github.com/darvaza-proxy/core v0.8.1
 
 require (
 	golang.org/x/net v0.8.0 // indirect

--- a/shared/web/go.sum
+++ b/shared/web/go.sum
@@ -1,7 +1,5 @@
-github.com/darvaza-proxy/core v0.7.4 h1:1XXVAkKyyESb7vUnIoC1vaxia/0lvzohOQTKSjfcFW0=
-github.com/darvaza-proxy/core v0.7.4/go.mod h1:M/zLq78zDLacjDXxOdO+TCCk5bUpEJXoVc2HbYS1jKY=
-github.com/darvaza-proxy/middleware v0.0.5 h1:nw8t3KqfTh4ZUnIOFUL+N/N6ZA93QRDb7+ARYP7EICM=
-github.com/darvaza-proxy/middleware v0.0.5/go.mod h1:7fy21UO1A6lrzd1h3JGusCewFpNM3Vpan+MR9GLvyAk=
+github.com/darvaza-proxy/core v0.8.1 h1:1ngmbUqQWaKWhC8LwdobJMhJgQi/NLpy7cRa6XmPp24=
+github.com/darvaza-proxy/core v0.8.1/go.mod h1:M/zLq78zDLacjDXxOdO+TCCk5bUpEJXoVc2HbYS1jKY=
 golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=


### PR DESCRIPTION
breaking the co-dependency between middleware and shared/web

```
package github.com/darvaza-proxy/middleware
        imports github.com/darvaza-proxy/darvaza/shared/web
        imports github.com/darvaza-proxy/middleware: import cycle not allowed
```