### PR TITLE
agent/httpserver: fix Alt-Svc support

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	darvaza.org/core v0.9.4
-	darvaza.org/darvaza/acme v0.1.1
+	darvaza.org/darvaza/acme v0.1.2
 	darvaza.org/darvaza/shared v0.5.3
 	darvaza.org/middleware v0.2.3
 	darvaza.org/slog v0.5.2

--- a/agent/httpserver/http3.go
+++ b/agent/httpserver/http3.go
@@ -138,14 +138,21 @@ func (srv *Server) grabQuicHeaders(ctx context.Context, h3s *http3.Server) error
 }
 
 func (srv *Server) appendQuicHeaders(altSvcs []string) {
+	var s []string
+
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 
-	s := strings.Split(",", srv.quicAltSvc)
+	if srv.quicAltSvc != "" {
+		s = strings.Split(srv.quicAltSvc, ",")
+	}
+
 	for i, hdr := range altSvcs {
 		srv.debug().Printf("%s[%v]: %s", AltSvcHeader, i, hdr)
 
-		for _, part := range strings.Split(",", hdr) {
+		for _, part := range strings.Split(hdr, ",") {
+			part = strings.TrimSpace(part)
+
 			if !core.SliceContains(s, part) {
 				s = append(s, part)
 			}


### PR DESCRIPTION
strings.Split() was being called with the arguments reversed, and a "" element was being left on the array