### PR TITLE
feat(build): drop Go 1.21 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       matrix:
-        go: [ '1.21', '1.22', '1.23' ]
+        go: [ '1.22', '1.23' ]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,9 +41,9 @@ linters-settings:
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - dupl
     - errcheck
-    - exportloopref
     - goconst
     - gocyclo
     - gofmt

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ OUTDIR ?= $(TMPDIR)
 
 # Dynamic version selection based on Go version
 # Format: $(TOOLSDIR)/get_version.sh <go_version> <tool_version1> <tool_version2> ..
-GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.21 v1.59 v1.61)
-REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.21 v1.4)
+GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.22 v1.63.4)
+REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.22 v1.4)
 
 GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 GOLANGCI_LINT ?= $(GO) run $(GOLANGCI_LINT_URL)

--- a/acme/go.mod
+++ b/acme/go.mod
@@ -1,6 +1,6 @@
 module darvaza.org/darvaza/acme
 
-go 1.21
+go 1.22
 
 require (
 	darvaza.org/core v0.15.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module darvaza.org/darvaza
 
-go 1.21
+go 1.22
 
 require (
 	darvaza.org/core v0.15.6

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "packageRules": [
     {
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "1.21"
+      "allowedVersions": "1.22"
     },
     {
       "groupName": "Darvaza Projects",

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module darvaza.org/darvaza/server
 
-go 1.21
+go 1.22
 
 require (
 	darvaza.org/core v0.15.6

--- a/shared/config/go.mod
+++ b/shared/config/go.mod
@@ -1,4 +1,4 @@
 // Deprecated: use darvaza.org/x/config instead
 module darvaza.org/darvaza/shared/config
 
-go 1.21
+go 1.22

--- a/shared/go.mod
+++ b/shared/go.mod
@@ -1,6 +1,6 @@
 module darvaza.org/darvaza/shared
 
-go 1.21
+go 1.22
 
 require (
 	darvaza.org/core v0.15.6

--- a/shared/storage/simple/simple.go
+++ b/shared/storage/simple/simple.go
@@ -45,6 +45,7 @@ type certInfo struct {
 	patterns []string
 }
 
+
 // init unconditionally initializes the Store
 func (s *Store) init() {
 	s.logger = defaultLogger()

--- a/shared/tls/server/server.go
+++ b/shared/tls/server/server.go
@@ -100,10 +100,7 @@ func (pc *ProxyConfig) New() *Proxy {
 // Run is starting a TLSproxy that accepts connections.
 func (p *Proxy) Run() error {
 	//revive:enable:cognitive:complexity
-	for l := range p.listeners {
-		// TODO: Go(func () error{}) means no l tag
-		// https://golang.org/doc/faq#closures_and_goroutines
-		lsn := l
+	for lsn := range p.listeners {
 		p.errGroup.Go(func() error {
 			for {
 				if p.shuttingDown() {
@@ -126,8 +123,6 @@ func (p *Proxy) Run() error {
 	return p.errGroup.Wait()
 }
 
-// TODO: reimplemet and fix revive
-//
 //revive:disable:cognitive-complexity
 func (p *Proxy) closeListeners() error {
 	//revive:enable:cognitive-complexity

--- a/shared/web/go.mod
+++ b/shared/web/go.mod
@@ -1,4 +1,4 @@
 // Deprecated: use darvaza.org/x/web instead
 module darvaza.org/darvaza/shared/web
 
-go 1.21
+go 1.22


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Chores**
	- Updated project to Go version 1.22
	- Updated development tools and linting configurations
	- Refined GitHub Actions workflow to support Go 1.22 and 1.23
	- Updated Renovate configuration for Go version management

- **Refactor**
	- Improved initialization process for storage and server components
	- Enhanced code readability in server proxy implementation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->